### PR TITLE
fix: incorrect renovate preset repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "renovate": {
     "extends": [
-      "github>1stG/congigs"
+      "github>1stG/configs"
     ]
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the Renovate configuration to ensure the proper configuration repository is referenced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->